### PR TITLE
Version Lock Requirements and Remove Application

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-zombie-slaves.py
-jenkins
-configparser
-python-novaclient
+python-jenkins==0.4.13
+configparser==3.5.0
+python-novaclient==6.0.0


### PR DESCRIPTION
Listing 'zombie-slaves.py' in the requirements file will cause pip to
search for it on pypi. Since it's not on pypi (yet) it will fail to find
it and error out.

Version locking the requirements will make sure the same ones get
installed each time and keep update to the dependencies from breaking
zombie-slaves.py.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>